### PR TITLE
docs: update Nuxt footnote to include `@unvuetify/nuxt-utils`

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,7 @@ VSCode directives suggestions | ❌                   | ❌                     
 [^2]: `@unvuetify/unplugin-vue-components-resolvers`.
 [^3]: `@unvuetify/unimport-presets`.
 [^4]: `vuetify-nuxt-module` will support all the features once updated using the packages in this monorepo.
-
-  `@unvuetify/nuxt-utils` supports all the features, but it is not a drop-in replacement for `vuetify-nuxt-module`.
+[^4]: `@unvuetify/nuxt-utils` supports all the features, but it is not a drop-in replacement for `vuetify-nuxt-module`.
 [^5]: `@unvuetify/unimport-presets` components preset can be used with Nuxt components loader, won't work with Vite.
 [^6]: `vite-plugin-vuetify` will work, but we can get some warnings about missing sources.
 [^7]: `webpack-plugin-vuetify` not tested with Nuxt 3 with or without SSR.

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ VSCode directives suggestions | ❌                   | ❌                     
 [^2]: `@unvuetify/unplugin-vue-components-resolvers`
 [^3]: `@unvuetify/unimport-presets`
 [^4]: `vuetify-nuxt-module` will support all the features once updated using the packages in this monorepo
+      `@unvuetify/nuxt-utils` supports all the features, but it is not a drop-in replacement for `vuetify-nuxt-module`
 [^5]: `@unvuetify/unimport-presets` components preset can be used with Nuxt components loader, won't work with Vite
 [^6]: `vite-plugin-vuetify` will work, but we can get some warnings about missing sources
 [^7]: `webpack-plugin-vuetify` not tested with Nuxt 3 with or without SSR

--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ VSCode directives suggestions | ❌                   | ❌                     
 [^2]: `@unvuetify/unplugin-vue-components-resolvers`.
 [^3]: `@unvuetify/unimport-presets`.
 [^4]: `vuetify-nuxt-module` will support all the features once updated using the packages in this monorepo.
+
   `@unvuetify/nuxt-utils` supports all the features, but it is not a drop-in replacement for `vuetify-nuxt-module`.
 [^5]: `@unvuetify/unimport-presets` components preset can be used with Nuxt components loader, won't work with Vite.
 [^6]: `vite-plugin-vuetify` will work, but we can get some warnings about missing sources.

--- a/README.md
+++ b/README.md
@@ -80,8 +80,7 @@ VSCode directives suggestions | ❌                   | ❌                     
 [^1]: `@unvuetify/vite-plugin-styles`.
 [^2]: `@unvuetify/unplugin-vue-components-resolvers`.
 [^3]: `@unvuetify/unimport-presets`.
-[^4]: `vuetify-nuxt-module` will support all the features once updated using the packages in this monorepo.
-[^4]: `@unvuetify/nuxt-utils` supports all the features, but it is not a drop-in replacement for `vuetify-nuxt-module`.
+[^4]: `vuetify-nuxt-module` will support all the features once updated using the packages in this monorepo.<br/>`@unvuetify/nuxt-utils` supports all the features, but it is not a drop-in replacement for `vuetify-nuxt-module`.
 [^5]: `@unvuetify/unimport-presets` components preset can be used with Nuxt components loader, won't work with Vite.
 [^6]: `vite-plugin-vuetify` will work, but we can get some warnings about missing sources.
 [^7]: `webpack-plugin-vuetify` not tested with Nuxt 3 with or without SSR.

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ VSCode directives suggestions | ❌                   | ❌                     
 [^2]: `@unvuetify/unplugin-vue-components-resolvers`
 [^3]: `@unvuetify/unimport-presets`
 [^4]: `vuetify-nuxt-module` will support all the features once updated using the packages in this monorepo
-      `@unvuetify/nuxt-utils` supports all the features, but it is not a drop-in replacement for `vuetify-nuxt-module`
+  `@unvuetify/nuxt-utils` supports all the features, but it is not a drop-in replacement for `vuetify-nuxt-module`
 [^5]: `@unvuetify/unimport-presets` components preset can be used with Nuxt components loader, won't work with Vite
 [^6]: `vite-plugin-vuetify` will work, but we can get some warnings about missing sources
 [^7]: `webpack-plugin-vuetify` not tested with Nuxt 3 with or without SSR

--- a/README.md
+++ b/README.md
@@ -77,15 +77,15 @@ prefix composables, directives and components | ❌                   | ❌     
 Nuxt Lazy Hydration | ❌                   | ❌                      | ❌                     | ❌             | ✅[^8]       | ✅
 VSCode directives suggestions | ❌                   | ❌                      | ❌                     | ❌             | ✅           | ✅
 
-[^1]: `@unvuetify/vite-plugin-styles`
-[^2]: `@unvuetify/unplugin-vue-components-resolvers`
-[^3]: `@unvuetify/unimport-presets`
-[^4]: `vuetify-nuxt-module` will support all the features once updated using the packages in this monorepo
-  `@unvuetify/nuxt-utils` supports all the features, but it is not a drop-in replacement for `vuetify-nuxt-module`
-[^5]: `@unvuetify/unimport-presets` components preset can be used with Nuxt components loader, won't work with Vite
-[^6]: `vite-plugin-vuetify` will work, but we can get some warnings about missing sources
-[^7]: `webpack-plugin-vuetify` not tested with Nuxt 3 with or without SSR
-[^8]: `@unvuetify/unimport-presets` components preset can be used with Nuxt imports
+[^1]: `@unvuetify/vite-plugin-styles`.
+[^2]: `@unvuetify/unplugin-vue-components-resolvers`.
+[^3]: `@unvuetify/unimport-presets`.
+[^4]: `vuetify-nuxt-module` will support all the features once updated using the packages in this monorepo.
+  `@unvuetify/nuxt-utils` supports all the features, but it is not a drop-in replacement for `vuetify-nuxt-module`.
+[^5]: `@unvuetify/unimport-presets` components preset can be used with Nuxt components loader, won't work with Vite.
+[^6]: `vite-plugin-vuetify` will work, but we can get some warnings about missing sources.
+[^7]: `webpack-plugin-vuetify` not tested with Nuxt 3 with or without SSR.
+[^8]: `@unvuetify/unimport-presets` components preset can be used with Nuxt imports.
 
 ## 📄 License
 

--- a/packages/nuxt-utils/README.md
+++ b/packages/nuxt-utils/README.md
@@ -68,9 +68,9 @@ export default defineNuxtConfig({
   /* other nuxt options */
   vuetify: {
     composables: { /* composables options */ },
-    components: { /* components options */ },  
-    directives: { /* directives options */ }, 
-    styles: { /* styles options */ }  
+    components: { /* components options */ },
+    directives: { /* directives options */ },
+    styles: { /* styles options */ }
   }
 })
 ```


### PR DESCRIPTION
closes #17
