### PR TITLE
fix(i18n): include decimal separator

### DIFF
--- a/packages/nuxt-i18n-utils/src/runtime/index.ts
+++ b/packages/nuxt-i18n-utils/src/runtime/index.ts
@@ -134,11 +134,16 @@ function createProvideFunction(data: {
     const t = wrapI18n(i18n.t)
     const n = wrapI18n(i18n.n)
 
+    function inferDecimalSeparator() {
+      return i18n.n(0.1).includes(',') ? ',' : '.'
+    }
+
     return <LocaleInstance>{
       name: '@unvuetify:nuxt-i18n-utils:adapter',
       current: currentLocale,
       fallback: data.fallback,
       messages: data.messages,
+      decimalSeparator: toRef(() => props.decimalSeparator ?? inferDecimalSeparator()),
       t,
       n,
       provide: createProvideFunction({ current: currentLocale, fallback: data.fallback, messages: data.messages }),

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -97,7 +97,7 @@ catalogs:
 overrides:
   nuxt: 3.17.1
   vite: 6.2.6
-  vuetify: ^3.8.1
+  vuetify: ^3.9.0
 
 importers:
 
@@ -161,8 +161,8 @@ importers:
         specifier: 'catalog:'
         version: 2.2.8(typescript@5.8.3)
       vuetify:
-        specifier: ^3.8.1
-        version: 3.8.1(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
+        specifier: ^3.9.0
+        version: 3.9.0(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
 
   packages/nuxt-i18n-utils:
     dependencies:
@@ -173,8 +173,8 @@ importers:
         specifier: ^8.0.0 || ^9.0.0 || ^10.0.0-0
         version: 9.5.4(@vue/compiler-dom@3.5.13)(eslint@9.24.0(jiti@2.4.2))(magicast@0.3.5)(rollup@4.40.0)(vue@3.5.13(typescript@5.8.3))
       vuetify:
-        specifier: ^3.8.1
-        version: 3.8.1(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
+        specifier: ^3.9.0
+        version: 3.9.0(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
 
   packages/nuxt-utils:
     dependencies:
@@ -198,8 +198,8 @@ importers:
         specifier: 'catalog:'
         version: 2.0.1
       vuetify:
-        specifier: ^3.8.1
-        version: 3.8.1(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
+        specifier: ^3.9.0
+        version: 3.9.0(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
 
   packages/styles-plugin:
     dependencies:
@@ -216,8 +216,8 @@ importers:
         specifier: 6.2.6
         version: 6.2.6(@types/node@22.14.1)(jiti@2.4.2)(sass-embedded@1.86.3)(terser@5.39.0)(tsx@4.19.3)(yaml@2.7.1)
       vuetify:
-        specifier: ^3.8.1
-        version: 3.8.1(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
+        specifier: ^3.9.0
+        version: 3.9.0(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
 
   packages/unimport-presets:
     dependencies:
@@ -249,8 +249,8 @@ importers:
         specifier: 'catalog:'
         version: 3.5.13(typescript@5.8.3)
       vuetify:
-        specifier: ^3.8.1
-        version: 3.8.1(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
+        specifier: ^3.9.0
+        version: 3.9.0(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
     devDependencies:
       '@nuxt/fonts':
         specifier: 'catalog:'
@@ -286,8 +286,8 @@ importers:
         specifier: 'catalog:'
         version: 3.5.13(typescript@5.8.3)
       vuetify:
-        specifier: ^3.8.1
-        version: 3.8.1(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
+        specifier: ^3.9.0
+        version: 3.9.0(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
     devDependencies:
       '@tsconfig/node22':
         specifier: 'catalog:'
@@ -344,8 +344,8 @@ importers:
         specifier: 'catalog:'
         version: 3.5.13(typescript@5.8.3)
       vuetify:
-        specifier: ^3.8.1
-        version: 3.8.1(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
+        specifier: ^3.9.0
+        version: 3.9.0(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
     devDependencies:
       '@tsconfig/node22':
         specifier: 'catalog:'
@@ -411,8 +411,8 @@ importers:
         specifier: 'catalog:'
         version: 3.5.13(typescript@5.8.3)
       vuetify:
-        specifier: ^3.8.1
-        version: 3.8.1(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
+        specifier: ^3.9.0
+        version: 3.9.0(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
     devDependencies:
       '@nuxtjs/i18n':
         specifier: 'catalog:'
@@ -445,8 +445,8 @@ importers:
         specifier: 'catalog:'
         version: 3.5.13(typescript@5.8.3)
       vuetify:
-        specifier: ^3.8.1
-        version: 3.8.1(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
+        specifier: ^3.9.0
+        version: 3.9.0(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
     devDependencies:
       '@nuxt/fonts':
         specifier: 'catalog:'
@@ -482,8 +482,8 @@ importers:
         specifier: 'catalog:'
         version: 3.5.13(typescript@5.8.3)
       vuetify:
-        specifier: ^3.8.1
-        version: 3.8.1(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
+        specifier: ^3.9.0
+        version: 3.9.0(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
     devDependencies:
       '@tsconfig/node22':
         specifier: 'catalog:'
@@ -540,8 +540,8 @@ importers:
         specifier: 'catalog:'
         version: 3.5.13(typescript@5.8.3)
       vuetify:
-        specifier: ^3.8.1
-        version: 3.8.1(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
+        specifier: ^3.9.0
+        version: 3.9.0(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3))
     devDependencies:
       '@tsconfig/node22':
         specifier: 'catalog:'
@@ -6075,8 +6075,8 @@ packages:
       typescript:
         optional: true
 
-  vuetify@3.8.1:
-    resolution: {integrity: sha512-3qReKBBWIIdJJmwnFU1blVIKHDtnLfIP7kk0MwUrrfjYkWmsDpsymtDnsukkTCnlJ1WvhLr64eQFosr0RVbj9w==}
+  vuetify@3.9.0:
+    resolution: {integrity: sha512-vjqyHP5gBFH4x0BAjdRAcS3FXY5OfHaKnC6Hhgln8tePZtKc3AUhF7BEJtcrD3l6XwL8gaYx/wMt+UP7X5EZJw==}
     engines: {node: ^12.20 || >=14.13}
     peerDependencies:
       typescript: '>=4.7'
@@ -12529,7 +12529,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.8.3
 
-  vuetify@3.8.1(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3)):
+  vuetify@3.9.0(typescript@5.8.3)(vue@3.5.13(typescript@5.8.3)):
     dependencies:
       vue: 3.5.13(typescript@5.8.3)
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -34,4 +34,4 @@ catalog:
   vite-plugin-inspect: ^11.0.0
   vue: ^3.5.13
   vue-tsc: ^2.2.8
-  vuetify: ^3.8.1
+  vuetify: ^3.9.0


### PR DESCRIPTION
### Description

- updates Vuetify workspace version to 3.9.0
- supplements missing `decimalSeparator` field

### Linked Issues

- [#324](https://github.com/vuetifyjs/nuxt-module/issues/324) from vuetifyjs/nuxt-module