### PR TITLE
fix: correct component lookup in labs components

### DIFF
--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -18,7 +18,7 @@ export interface ImportComponents {
   directives: DirectiveName[]
 }
 export interface ImportLabsComponents {
-  [key: string]: VuetifyComponent
+  components: VuetifyComponents
 }
 export type ImportMaps = [importMaps: Promise<ImportComponents>, importMapsLabs: Promise<ImportLabsComponents>]
 

--- a/packages/unplugin-vue-components-resolvers/src/index.ts
+++ b/packages/unplugin-vue-components-resolvers/src/index.ts
@@ -79,8 +79,8 @@ function createComponentsResolver(
       const [components, labsComponents] = await Promise.all(promises)
       const component = vuetifyName in components.components
         ? components.components[vuetifyName]
-        : labs && vuetifyName in labsComponents
-          ? labsComponents[vuetifyName]
+        : labs && vuetifyName in labsComponents.components
+          ? labsComponents.components[vuetifyName]
           : undefined
 
       if (!component)

--- a/playgrounds/basic-resolvers/src/App.vue
+++ b/playgrounds/basic-resolvers/src/App.vue
@@ -58,6 +58,9 @@ function onClick() {
                   </template>
                 </v-card>
               </v-col>
+              <v-col cols="12">
+                <v-stepper-vertical :items="['Step 1', 'Step 2', 'Step 3']" />
+              </v-col>
             </v-row>
           </v-col>
         </v-row>

--- a/playgrounds/prefix-resolvers/src/App.vue
+++ b/playgrounds/prefix-resolvers/src/App.vue
@@ -60,6 +60,9 @@ function onClick() {
               </vuetify-col>
             </vuetify-row>
           </vuetify-col>
+          <vuetify-col cols="12">
+            <vuetify-stepper-vertical :items="['Step 1', 'Step 2', 'Step 3']" />
+          </vuetify-col>
         </vuetify-row>
       </vuetify-container>
     </vuetify-main>


### PR DESCRIPTION
### Description

Labs components are also scoped and currently all labs components resolve as undefined
PR resolves labs components from the `components` scope + adds labs component to playground

### Linked Issues

<!-- e.g. fixes #123 -->

### Additional Context

<!-- Is there anything you would like the reviewers to focus on? -->
